### PR TITLE
"Capture" feature

### DIFF
--- a/lib/dnote/note.rb
+++ b/lib/dnote/note.rb
@@ -6,12 +6,14 @@ module DNote
     attr :label
     attr :line
     attr :text
+    attr :capture
 
     def initialize(file, label, line, text)
       @file  = file
       @label = label
       @line  = line
       @text  = text.rstrip
+      @capture = []
     end
 
     #

--- a/lib/dnote/notes.rb
+++ b/lib/dnote/notes.rb
@@ -85,6 +85,7 @@ module DNote
         mark = remark(fname)
         File.open(fname) do |f|
           lineno, save, text = 0, nil, nil
+          capture = 0
           while line = f.gets
             lineno += 1
             save = match(line, lineno, fname)
@@ -99,7 +100,8 @@ module DNote
                 when /^\s*#{mark}+\s*$/, /(?!^\s*#{mark})/, /^\s*#{mark}[+][+]/
                   text.strip!
                   text = nil
-                else
+                  capture = 5
+                else                  
                   if text[-1,1] == "\n"
                     text << line.gsub(/^\s*#{mark}\s*/,'')
                   else
@@ -107,6 +109,10 @@ module DNote
                   end
                 end
               end
+            end
+            if capture > 0
+              records.last.capture << line 
+              capture = capture -= 1  
             end
           end
         end

--- a/lib/dnote/templates/html.erb
+++ b/lib/dnote/templates/html.erb
@@ -21,15 +21,22 @@
 <body>
 <div class="main">
   <h1><%= title %></h1>
+  <ol> 
+        <% notes.dup.counts.each_pair do |l, n| %>
+        <li><a href="#<%= l %>"><%= l %></a></li>
+        <% end %>
+  </ol>
   <div class="notes">
 <% notes.by_label_file.each do |label, per_file| %>
-    <h2><%= label %></h2>
+    <h2 id="<%= label %>"><%= label %></h2>
     <ol class="set <%= label.downcase %>">
 <% per_file.each do |file, line_notes| %>
       <li><h3><a href="<%= file %>"><%= file %></a></h3><ol class="file" href="<%= file %>">
 <% line_notes.sort!{ |a,b| a.line <=> b.line } %>
 <% line_notes.each do |note| %>
-        <li class="note <%= label.downcase %>" ref="<%= note.line %>"><%= h note.text %> <sup><%= note.line %></sup></li>
+        <li class="note <%= label.downcase %>" ref="<%= note.line %>"><%= h note.text %> <sup><%= note.line %></sup>
+        <pre><%= note.capture.join %></pre>
+        </li>
 <% end %>
       </ol></li>
 <% end %>


### PR DESCRIPTION
 I added the "capture source" story to dnote: now the html report shows a 5 lines chunk from the original source file, captureds just after the marker coment ends. This way the user can view the note and the context it originated. I found in my daily work very useful for a quick review of my notes.

Hope this help to enhance this useful tool
