### PR TITLE
Avoid name clash with built-in String

### DIFF
--- a/lib/dnote/core_ext.rb
+++ b/lib/dnote/core_ext.rb
@@ -15,7 +15,7 @@ module DNote
   # Extensions for String class.
   # These methods are taken directly from Ruby Facets.
   #
-  module String
+  module StringExt
 
     # Provides a margin controlled string.
     #
@@ -85,7 +85,7 @@ module DNote
   end
 
   class ::String #:nodoc:
-    include DNote::String
+    include DNote::StringExt
   end
 
 end


### PR DESCRIPTION
This fixes an error on Ruby 2.4 where dnote aborts with the message

```
undefined method `new' for DNote::String:Module
```